### PR TITLE
feat: basic url support for shader source

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@ This repo tracks the development of an easy to use offscreen canvas for WebGL sh
 > [!WARNING]
 > This project is under active development.
 
+## Example
+
+Here's how to use the `OffscreenWebGL` component. This example uses a GLSL file hosted on the public folder, and creates an offscreen canvas element with a web worker attached that renders the shader source.
+
+```glsl
+// /public/shader.glsl
+precision highp float;
+uniform vec2 u_resolution;
+
+void main() {
+	vec2 uv = gl_FragCoord.xy / u_resolution;
+	gl_FragColor = vec4(uv.x, uv.y, 0., 1.);
+}
+```
+
+```jsx
+// /src/App.jsx
+import { OffscreenWebGL } from 'react-offscreen-webgl';
+
+function App() {
+	return (
+		<div>
+			<OffscreenWebGL fragmentShaderURL={'shader.glsl'} />
+		</div>
+	);
+}
+
+export default App;
+```
+
 ## Contributing
 
 If you want to contribute to this project, be sure to check the issues and the [project used to track them](https://github.com/users/tomaspietravallo/projects/4). Be sure to check [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.

--- a/src/offscreen-webgl/gl-manager.ts
+++ b/src/offscreen-webgl/gl-manager.ts
@@ -87,13 +87,19 @@ export class WebGLManager {
 		return ok(this);
 	}
 
-	public compileProgram(vertexShaderSource: string, fragmentShaderSources: string[]): Result<WebGLManager> {
+	public setVertexShader(vertexShaderSource: string): Result<WebGLManager> {
 		const { data: vertexShader, error: vertexShaderErr } = createShaderFromSource(this.gl, this.gl.VERTEX_SHADER, vertexShaderSource);
 
 		if (vertexShaderErr) {
 			return err(new Error(`[OffscreenCanvas @ GLManager] Failed to compile Vertex Shader: ${vertexShaderErr}`));
-		} else this.vertexShader = vertexShader;
+		} else {
+			this.vertexShader = vertexShader;
+		}
 
+		return ok(this);
+	}
+
+	public setFragmentShaders(fragmentShaderSources: string[]): Result<WebGLManager> {
 		const fs = [];
 
 		try {
@@ -114,6 +120,55 @@ export class WebGLManager {
 		}
 
 		return ok(this);
+	}
+
+	public setRemoteVertexShader(url: string): Promise<Result<WebGLManager>> {
+		return fetch(url)
+			.then((response) => {
+				if (!response.ok) {
+					throw new Error(`[OffscreenCanvas @ GLManager] Failed to fetch vertex shader from ${url}`);
+				}
+				return response.text();
+			})
+			.then((shaderText) => {
+				console.log('SET VERTEX SHADERS');
+				return this.setVertexShader(shaderText);
+			})
+			.catch((error) => err(new Error(`[OffscreenCanvas @ GLManager] Error fetching vertex shader: ${error.message}`)));
+	}
+
+	public setRemoteFragmentShaders(urls: string | string[]): Promise<Result<WebGLManager>> {
+		if (typeof urls === 'string') {
+			urls = [urls];
+		}
+
+		const fetchPromises = urls.map((url) =>
+			fetch(url)
+				.then(async (response) => {
+					if (!response.ok) {
+						throw new Error(`[OffscreenCanvas @ GLManager] Failed to fetch fragment shader from ${url}`);
+					}
+					return ok(await response.text());
+				})
+				.catch((error) => err(new Error(`[OffscreenCanvas @ GLManager] Error fetching fragment shader: ${error.message}`)))
+		);
+
+		return Promise.all(fetchPromises)
+			.then((results) => {
+				const errors = results.filter((result) => result.error);
+				if (errors.length > 0) {
+					return err(
+						new Error(
+							`[OffscreenCanvas @ GLManager] Errors fetching fragment shaders: ${errors.map((e) => e.error?.message).join(', ')}`
+						)
+					);
+				}
+				const fragmentShaderSources = results.map((result) => result.data!);
+				return this.setFragmentShaders(fragmentShaderSources);
+			})
+			.catch((error) => {
+				return err(new Error(`[OffscreenCanvas @ GLManager] Error setting remote fragment shaders: ${error.message}`));
+			});
 	}
 
 	public useProgram(): Result<WebGLManager> {

--- a/src/offscreen-webgl/gl-manager.ts
+++ b/src/offscreen-webgl/gl-manager.ts
@@ -131,7 +131,6 @@ export class WebGLManager {
 				return response.text();
 			})
 			.then((shaderText) => {
-				console.log('SET VERTEX SHADERS');
 				return this.setVertexShader(shaderText);
 			})
 			.catch((error) => err(new Error(`[OffscreenCanvas @ GLManager] Error fetching vertex shader: ${error.message}`)));

--- a/src/offscreen-webgl/offscreen-webgl.tsx
+++ b/src/offscreen-webgl/offscreen-webgl.tsx
@@ -6,7 +6,9 @@ import { WebGLManagerProxy, WebGLManagerProxyType } from './proxy';
 
 interface OffscreenWebGLProps {
 	vertexShader?: string;
+	vertexShaderURL?: string;
 	fragmentShader?: string;
+	fragmentShaderURL?: string;
 	refreshRate?: number; // in FPS, default is 30
 	disableResizeObserver?: boolean;
 
@@ -49,7 +51,28 @@ export const OffscreenWebGL: FC<OffscreenWebGLProps> = (props: OffscreenWebGLPro
 		proxyRef.current = new WebGLManagerProxy(canvas) as any as WebGLManagerProxyType;
 
 		new Promise(async (resolve) => {
-			await proxyRef.current?.compileProgram(vertexShader, [fragmentShader]);
+			let vertexShaderText = vertexShader;
+			let fragmentShaderText = fragmentShader;
+
+			if (props.vertexShaderURL) {
+				const response = await fetch(props.vertexShaderURL);
+				if (!response.ok) {
+					throw new Error(`[OffscreenWebGL] Failed to fetch vertex shader from ${props.vertexShaderURL}`);
+				}
+				const shaderText = await response.text();
+				vertexShaderText = shaderText;
+			}
+
+			if (props.fragmentShaderURL) {
+				const response = await fetch(props.fragmentShaderURL);
+				if (!response.ok) {
+					throw new Error(`[OffscreenWebGL] Failed to fetch fragment shader from ${props.fragmentShaderURL}`);
+				}
+				const shaderText = await response.text();
+				fragmentShaderText = shaderText;
+			}
+
+			await proxyRef.current?.compileProgram(vertexShaderText, [fragmentShaderText]);
 
 			await proxyRef.current?.useProgram();
 

--- a/src/offscreen-webgl/offscreen-webgl.tsx
+++ b/src/offscreen-webgl/offscreen-webgl.tsx
@@ -22,6 +22,8 @@ export const OffscreenWebGL: FC<OffscreenWebGLProps> = (props: OffscreenWebGLPro
 	const CANVAS_ID = useRef(`OffscreenWebGLCanvas-${uuidv4()}`);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const proxyRef = useRef<WebGLManagerProxyType | null>(null);
+	const __setupPromise_resolve = useRef<((value: void | PromiseLike<void>) => void) | null>(null);
+	const setupPromise = useRef<Promise<void>>(new Promise<void>((resolve) => (__setupPromise_resolve.current = resolve)));
 
 	const uDeps = useMemo(
 		() =>
@@ -50,35 +52,28 @@ export const OffscreenWebGL: FC<OffscreenWebGLProps> = (props: OffscreenWebGLPro
 
 		proxyRef.current = new WebGLManagerProxy(canvas) as any as WebGLManagerProxyType;
 
-		new Promise(async (resolve) => {
+		new Promise<void>(async (resolve) => {
 			let vertexShaderText = vertexShader;
 			let fragmentShaderText = fragmentShader;
 
 			if (props.vertexShaderURL) {
-				const response = await fetch(props.vertexShaderURL);
-				if (!response.ok) {
-					throw new Error(`[OffscreenWebGL] Failed to fetch vertex shader from ${props.vertexShaderURL}`);
-				}
-				const shaderText = await response.text();
-				vertexShaderText = shaderText;
+				await proxyRef.current?.setRemoteVertexShaderAsync(new URL(props.vertexShaderURL, window.location.origin).toString());
+			} else {
+				await proxyRef.current?.setVertexShaderAsync(vertexShaderText);
 			}
 
 			if (props.fragmentShaderURL) {
-				const response = await fetch(props.fragmentShaderURL);
-				if (!response.ok) {
-					throw new Error(`[OffscreenWebGL] Failed to fetch fragment shader from ${props.fragmentShaderURL}`);
-				}
-				const shaderText = await response.text();
-				fragmentShaderText = shaderText;
+				await proxyRef.current?.setRemoteFragmentShadersAsync(new URL(props.fragmentShaderURL, window.location.origin).toString());
+			} else {
+				await proxyRef.current?.setFragmentShadersAsync([fragmentShaderText]);
 			}
-
-			await proxyRef.current?.compileProgram(vertexShaderText, [fragmentShaderText]);
 
 			await proxyRef.current?.useProgram();
 
 			await proxyRef.current?.setupWholeScreenQuad();
 
 			await proxyRef.current?.paintCanvas();
+			resolve(__setupPromise_resolve.current?.());
 		}).catch(console.error);
 
 		return () => {};
@@ -86,6 +81,8 @@ export const OffscreenWebGL: FC<OffscreenWebGLProps> = (props: OffscreenWebGLPro
 
 	useEffect(() => {
 		new Promise(async (resolve) => {
+			await setupPromise.current;
+
 			if (!proxyRef.current || (await proxyRef.current.checkWebGLVitalsAsync()).error) {
 				console.warn('[OffscreenWebGL] WebGLManager is not ready yet');
 				return;
@@ -106,41 +103,49 @@ export const OffscreenWebGL: FC<OffscreenWebGLProps> = (props: OffscreenWebGLPro
 	}, uDeps);
 
 	useEffect(() => {
-		proxyRef.current?.checkWebGLVitalsAsync().then((result) => {
-			for (const [key, value] of Object.entries(props).filter(([key]) => key.startsWith('f_'))) {
-				proxyRef.current?.runOnContext(key, value, key.includes('each'));
-			}
+		setupPromise.current.then(() => {
+			proxyRef.current?.checkWebGLVitalsAsync().then((result) => {
+				for (const [key, value] of Object.entries(props).filter(([key]) => key.startsWith('f_'))) {
+					proxyRef.current?.runOnContext(key, value, key.includes('each'));
+				}
+			});
 		});
 	}, fDeps);
 
 	useEffect(() => {
-		if (!proxyRef.current) return;
+		setupPromise.current.then(() => {
+			if (!proxyRef.current) return;
 
-		if (props.refreshRate && props.refreshRate > 0) {
-			console.log(`[OffscreenWebGL] Setting refresh rate to ${props.refreshRate} FPS`);
-			proxyRef.current.setFrameRate(props.refreshRate);
-		} else {
-			if (props.refreshRate) {
-				console.warn(`[OffscreenWebGL] Invalid refresh rate, using default (${WebGLManager.DEFAULT_FRAME_RATE} FPS)`);
+			if (props.refreshRate && props.refreshRate > 0) {
+				console.log(`[OffscreenWebGL] Setting refresh rate to ${props.refreshRate} FPS`);
+				proxyRef.current.setFrameRate(props.refreshRate);
+			} else {
+				if (props.refreshRate) {
+					console.warn(`[OffscreenWebGL] Invalid refresh rate, using default (${WebGLManager.DEFAULT_FRAME_RATE} FPS)`);
+				}
+				proxyRef.current.setFrameRate(30);
 			}
-			proxyRef.current.setFrameRate(30);
-		}
+		});
 	}, [props.refreshRate]);
 
 	useEffect(() => {
-		const canvas = canvasRef.current;
-		if (!canvas || !proxyRef.current || disableResizeObserver) return;
+		let observer: ResizeObserver | null = null;
 
-		const observer = new ResizeObserver(() => {
-			if (disableResizeObserver) return observer.disconnect();
-			proxyRef.current?.resize(canvasRef.current?.width!, canvasRef.current?.height!);
-			proxyRef.current?.updateUniform('u_resolution', [canvasRef.current?.width!, canvasRef.current?.height!]);
+		setupPromise.current.then(() => {
+			const canvas = canvasRef.current;
+			if (!canvas || !proxyRef.current || disableResizeObserver) return;
+
+			observer = new ResizeObserver(() => {
+				if (disableResizeObserver) return observer?.disconnect();
+				proxyRef.current?.resize(canvasRef.current?.width!, canvasRef.current?.height!);
+				proxyRef.current?.updateUniform('u_resolution', [canvasRef.current?.width!, canvasRef.current?.height!]);
+			});
+
+			observer.observe(canvas);
 		});
 
-		observer.observe(canvas);
-
 		return () => {
-			observer.disconnect();
+			observer?.disconnect();
 		};
 	}, [disableResizeObserver]);
 

--- a/src/offscreen-webgl/proxy.ts
+++ b/src/offscreen-webgl/proxy.ts
@@ -110,6 +110,11 @@ class WebGLManagerProxyClass {
 		...args: any[]
 	): Promise<ReturnType<WebGLManager[ManagerMethod] extends (...args: any) => any ? WebGLManager[ManagerMethod] : never>> {
 		const id = uuidv4();
+
+		const promise = new Promise((resolve) => {
+			WebGLManagerProxyClass.pendingResponses[id] = resolve;
+		}) as ReturnType<WebGLManager[ManagerMethod] extends (...args: any) => any ? WebGLManager[ManagerMethod] : never>;
+
 		WebGLManagerProxyClass.worker?.postMessage({
 			type: WorkerMessageType.CALL_METHOD,
 			proxyId: this.PROXY_ID,
@@ -118,9 +123,8 @@ class WebGLManagerProxyClass {
 			id,
 			async: true,
 		} as WorkerMessages);
-		return new Promise((resolve) => {
-			WebGLManagerProxyClass.pendingResponses[id] = resolve;
-		});
+
+		return promise;
 	}
 
 	public runOnContext(key: string, fn: RunOnWorkerContextFn, onEachFrame: boolean = false) {

--- a/src/offscreen-webgl/webgl.worker.ts
+++ b/src/offscreen-webgl/webgl.worker.ts
@@ -81,7 +81,11 @@ addEventListener('message', async (event: MessageEvent<WorkerMessages>) => {
 					const result = await (glManagers[data.proxyId] as any)[method](...args);
 					if (async) postMessage({ type: WorkerMessageType.RESPONSE, id, result: JSON.stringify(result) });
 				} catch (error) {
-					postMessage({ type: WorkerMessageType.RESPONSE, id, error: JSON.stringify(error) });
+					postMessage({
+						type: WorkerMessageType.RESPONSE,
+						id,
+						error: `[OffscreenWebGLWorker, ${WORKER_ID}]: Error on method "${method}", args: ${args}.\n${JSON.stringify(error)}`,
+					});
 				}
 				break;
 			}

--- a/tests/vite/public/default-blue-1.glsl
+++ b/tests/vite/public/default-blue-1.glsl
@@ -1,0 +1,7 @@
+precision highp float;
+uniform vec2 u_resolution;
+
+void main() {
+	vec2 uv = gl_FragCoord.xy / u_resolution;
+	gl_FragColor = vec4(uv.x, uv.y, 1., 1.);
+}

--- a/tests/vite/public/default.glsl
+++ b/tests/vite/public/default.glsl
@@ -1,0 +1,7 @@
+precision highp float;
+uniform vec2 u_resolution;
+
+void main() {
+	vec2 uv = gl_FragCoord.xy / u_resolution;
+	gl_FragColor = vec4(uv.x, uv.y, 0., 1.);
+}

--- a/tests/vite/src/App.jsx
+++ b/tests/vite/src/App.jsx
@@ -9,6 +9,7 @@ function OffscreenWebGLContainer(props) {
 				f_each_paint={(manager, frame, time) => {
 					manager.paintCanvas();
 				}}
+				{...props}
 			/>
 		</div>
 	);
@@ -30,8 +31,8 @@ function App() {
 			>
 				<h1>Testing / Development environment</h1>
 				<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gridTemplateRows: 'repeat(1, 1fr)', gap: '20px' }}>
-					<OffscreenWebGLContainer />
-					<OffscreenWebGLContainer />
+					<OffscreenWebGLContainer fragmentShaderURL={'default.glsl'} />
+					<OffscreenWebGLContainer fragmentShaderURL={'default-blue-1.glsl'} />
 					<OffscreenWebGLContainer />
 				</div>
 			</header>


### PR DESCRIPTION
Fetch `props.fragmentShaderURL` and use that as source for the shader code.

This could be offloaded to the web worker later on....